### PR TITLE
Fix master/develop checkout commands for bgit forks

### DIFF
--- a/bgit
+++ b/bgit
@@ -186,10 +186,10 @@ function verify_fork() {
 
   #ensure there's a develop and master branch locally
   if [ $(git branch | grep " develop$" | wc -l) = "0" ]; then
-    git branch -f develop
+    git branch -f develop remotes/origin/develop
   fi
   if [ $(git branch | grep " master$" | wc -l) = "0" ]; then
-    git branch -f master
+    git branch -f master remotes/origin/master
   fi
 
   return 0


### PR DESCRIPTION
Forgot to specify the branch to create master and develop branches
from, which could lead to trying to merge the wrong branches together
when running bgit fupdate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-tools/8)
<!-- Reviewable:end -->
